### PR TITLE
Add enable/disable tcp adb quick settings tile

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.jmzsoftware.jmzwirelessadb">
 
-    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
     <application
         android:allowBackup="false"
@@ -19,5 +19,15 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".QuickSettingTileService"
+            android:icon="@drawable/ic_quick_setting"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
     </application>
 </manifest>

--- a/app/src/main/java/com/jmzsoftware/jmzwirelessadb/MainActivity.kt
+++ b/app/src/main/java/com/jmzsoftware/jmzwirelessadb/MainActivity.kt
@@ -43,30 +43,14 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
         button.setOnClickListener {
             if (button.text == resources.getString(R.string.disable)) {
-                disableAdb()
+                ShellCommands.disableAdb()
                 textView.text = ""
                 button.text = resources.getString(R.string.enable)
             } else {
-                enableAdb()
+                ShellCommands.enableAdb()
                 textView.text = resources.getString(R.string.noti, ip)
                 button.text = resources.getString(R.string.disable)
             }
         }
-    }
-
-    private fun enableAdb() {
-        runCommands(arrayOf("setprop service.adb.tcp.port 5555", "stop adbd", "start adbd"))
-    }
-
-    private fun disableAdb() {
-        runCommands(arrayOf("setprop service.adb.tcp.port 0", "stop adbd"))
-    }
-
-    private fun runCommands(cmds: Array<String>) {
-        try {
-            Shell.Pool.SU.run(cmds)
-        } catch (ignored: Shell.ShellDiedException) {
-        }
-
     }
 }

--- a/app/src/main/java/com/jmzsoftware/jmzwirelessadb/QuickSettingTileService.kt
+++ b/app/src/main/java/com/jmzsoftware/jmzwirelessadb/QuickSettingTileService.kt
@@ -1,0 +1,43 @@
+package com.jmzsoftware.jmzwirelessadb
+
+import android.annotation.TargetApi
+import android.os.Build
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+
+@TargetApi(Build.VERSION_CODES.N)
+class QuickSettingTileService : TileService() {
+
+    override fun onStartListening() {
+        qsTile.updateStateAndSubtitle()
+    }
+
+    override fun onClick() {
+        with(qsTile) {
+            if (state == Tile.STATE_ACTIVE) {
+                ShellCommands.disableAdb()
+            } else {
+                ShellCommands.enableAdb()
+            }
+            updateStateAndSubtitle()
+        }
+    }
+
+    private fun Tile.updateStateAndSubtitle() {
+        val isEnabled = ShellCommands.isAdbTcpEnabled()
+
+        state = if (isEnabled) {
+            Tile.STATE_ACTIVE
+        } else {
+            Tile.STATE_INACTIVE
+        }
+
+        subtitle = if (isEnabled) {
+            getString(R.string.disable)
+        } else {
+            getString(R.string.enable)
+        }
+
+        updateTile()
+    }
+}

--- a/app/src/main/java/com/jmzsoftware/jmzwirelessadb/ShellCommands.kt
+++ b/app/src/main/java/com/jmzsoftware/jmzwirelessadb/ShellCommands.kt
@@ -1,0 +1,33 @@
+package com.jmzsoftware.jmzwirelessadb
+
+import eu.chainfire.libsuperuser.Shell
+
+object ShellCommands {
+
+    private const val ADB_TCP_PORT_SYSTEM_PROP = "service.adb.tcp.port"
+    private const val ADB_PORT = "5555"
+
+    fun enableAdb() {
+        runCommands(arrayOf("setprop $ADB_TCP_PORT_SYSTEM_PROP $ADB_PORT", "stop adbd", "start adbd"))
+    }
+
+    fun disableAdb() {
+        runCommands(arrayOf("setprop $ADB_TCP_PORT_SYSTEM_PROP 0", "stop adbd"))
+    }
+
+    fun isAdbTcpEnabled() = try {
+        val command = "getprop $ADB_TCP_PORT_SYSTEM_PROP"
+        val stdout = mutableListOf<String>()
+        Shell.Pool.SH.run(arrayOf(command), stdout, mutableListOf<String>(), true)
+        stdout.any { it.trim() == ADB_PORT }
+    } catch (ignored: Shell.ShellDiedException) {
+        false
+    }
+
+    private fun runCommands(cmds: Array<String>) {
+        try {
+            Shell.Pool.SU.run(cmds)
+        } catch (ignored: Shell.ShellDiedException) {
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_quick_setting.xml
+++ b/app/src/main/res/drawable/ic_quick_setting.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M5,16c0,3.87 3.13,7 7,7s7,-3.13 7,-7v-4L5,12v4zM16.12,4.37l2.1,-2.1 -0.82,-0.83 -2.3,2.31C14.16,3.28 13.12,3 12,3s-2.16,0.28 -3.09,0.75L6.6,1.44l-0.82,0.83 2.1,2.1C6.14,5.64 5,7.68 5,10v1h14v-1c0,-2.32 -1.14,-4.36 -2.88,-5.63zM9,9c-0.55,0 -1,-0.45 -1,-1s0.45,-1 1,-1 1,0.45 1,1 -0.45,1 -1,1zM15,9c-0.55,0 -1,-0.45 -1,-1s0.45,-1 1,-1 1,0.45 1,1 -0.45,1 -1,1z"/>
+</vector>


### PR DESCRIPTION
I wasn't able to fully test the thing as I don't have a rooted device, I tested it on an emulator by manually setting and removing the system property with adb.
Even though the app didn't have root access, it was reading the property with `Shell.Pool.SH.run`.
The icon is taken from material design icon set available in Android Studio.